### PR TITLE
Fix markdown links to open in new tab

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown/SafeMarkdown.tsx
@@ -37,6 +37,12 @@ export function getOverrideHtmlSchema(
   );
 }
 
+// Custom link transformer to make all links open in new tab
+const transformLinkUri = (uri: string) => {
+  // Return the URI as-is, but we'll handle the target attribute in the component
+  return uri;
+};
+
 export function SafeMarkdown({
   source,
   htmlSanitization = true,
@@ -79,7 +85,12 @@ export function SafeMarkdown({
       rehypePlugins={rehypePlugins}
       remarkPlugins={[remarkGfm]}
       skipHtml={false}
-      transformLinkUri={null}
+      transformLinkUri={transformLinkUri}
+      components={{
+        a: ({ node, ...props }) => (
+          <a {...props} target="_blank" rel="noopener noreferrer" />
+        ),
+      }}
     >
       {source}
     </ReactMarkdown>

--- a/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.ts
@@ -16,7 +16,36 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { render } from '@testing-library/react';
+import { SafeMarkdown } from '../../src/components/SafeMarkdown/SafeMarkdown';
 import { getOverrideHtmlSchema } from '../../src/components/SafeMarkdown/SafeMarkdown';
+
+describe('SafeMarkdown', () => {
+  it('should render links with target="_blank" and rel="noopener noreferrer"', () => {
+    const markdownSource = '[🎧 Support](https://example.com)';
+    const { container } = render(<SafeMarkdown source={markdownSource} />);
+    
+    const link = container.querySelector('a');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(link).toHaveTextContent('🎧 Support');
+  });
+
+  it('should render multiple links with correct attributes', () => {
+    const markdownSource = '[Link 1](https://example1.com) and [Link 2](https://example2.com)';
+    const { container } = render(<SafeMarkdown source={markdownSource} />);
+    
+    const links = container.querySelectorAll('a');
+    expect(links).toHaveLength(2);
+    
+    links.forEach(link => {
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+  });
+});
 
 describe('getOverrideHtmlSchema', () => {
   it('should append the override items', () => {


### PR DESCRIPTION
```
feat(markdown): Open markdown links in new tab

### SUMMARY
This PR modifies the `SafeMarkdown` component to ensure that all markdown links (`[text](url)`) rendered within Superset, particularly in dashboard text elements, open in a new browser tab. Previously, these links would open in the current tab, navigating users away from the dashboard. This change improves user experience by preserving the current view when external links are clicked.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (Behavioral change, not visual layout)

### TESTING INSTRUCTIONS
1. Go to any dashboard in edit mode.
2. Add a "Text" layout element.
3. In the text element's content, add a markdown link, e.g., `[Google](https://www.google.com)`.
4. Save the dashboard.
5. View the dashboard and click on the newly added markdown link.
6. Verify that the link opens in a new browser tab/window.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI (behavioral change for links)
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API (new behavior for existing feature)
- [ ] Removes existing feature or API
```